### PR TITLE
feat(paragraph): add prepareSoftbreak method and refactor Shift+Enter…

### DIFF
--- a/src/lib/blocks/block.svelte.js
+++ b/src/lib/blocks/block.svelte.js
@@ -306,47 +306,6 @@ export class Block {
         } else return null;
     }
 
-    /**
-     * Determines the relative position of the block in the document.
-     * @param {any} [hint] - Optional hint to specify the desired relative position ('before', 'after', 'start', 'end').
-     * @returns {any} - The relative position, which can be 'before', 'after', or an object representing a selection.
-     */
-    getRelativePosition(hint) {
-        // Par défaut, on ne supporte que 'before' ou 'after'
-        if (hint === "start" || hint === "before") return "before";
-        if (hint === "end" || hint === "after") return "after";
-
-        // Si le bloc a une sélection active, la capturer
-        if (this.selected && window.getSelection) {
-            const sel = window.getSelection();
-            if (!sel) return;
-            const range = sel.getRangeAt(0);
-            const startInMe = this.element?.contains(range.startContainer);
-            const endInMe = this.element?.contains(range.endContainer);
-
-            // Si la sélection est dans mon element
-            if (this.element?.contains(range.startContainer)) {
-                return {
-                    type: "selection",
-                    ...(startInMe
-                        ? {
-                              startPath: this.getNodePath(range.startContainer),
-                              startOffset: range.startOffset,
-                          }
-                        : { startPath: null, startOffset: 0 }),
-                    ...(endInMe
-                        ? {
-                              endPath: this.getNodePath(range.endContainer),
-                              endOffset: range.endOffset,
-                          }
-                        : { endPath: null, endOffset: 0 }),
-                };
-            }
-        }
-
-        return "before"; // Fallback
-    }
-
     /** @type {Object<string, any>} */
     metadata = $state({});
 
@@ -510,17 +469,6 @@ export class Block {
         };
     }
 
-    toObject() {
-        return {
-            type: this.type,
-        };
-    }
-
-    toInit() {
-        return {
-            type: this.type,
-        };
-    }
 
     /** @type {BlockManifest} */
     get manifest() {
@@ -544,18 +492,6 @@ export class Block {
      */
     $in(data) {
         console.warn("Block input handler not implemented:", data);
-    }
-
-    /**
-     * @param {Object} data
-     */
-    snapshot(data) {
-        return {
-            id: this.id,
-            type: this.type,
-            metadata: this.metadata,
-            ...data,
-        };
     }
 
     /** @param {...import('../utils/operations.utils').Ops} ops */

--- a/src/lib/blocks/text/text.svelte.js
+++ b/src/lib/blocks/text/text.svelte.js
@@ -367,33 +367,7 @@ export class Text extends Block {
             },
         };
     }
-
-    toObject() {
-        return {
-            type: "text",
-            text: this.text,
-            ...this.getStyles(),
-        };
-    }
-
-    toInit() {
-        return {
-            ...super.toInit(),
-            init: {
-                text: this.text,
-                ...this.getStyles(),
-            },
-        };
-    }
-
     toMarkdown() {}
-
-    getRelativePosition() {
-        return {
-            start: this.start,
-            end: this.end,
-        };
-    }
 
     /**
      * @param {{


### PR DESCRIPTION
… handling

This commit introduces a new `prepareSoftbreak` method to the Paragraph class that handles linebreak insertion at a specified position or the current selection.

Changes:
- Add prepareSoftbreak method with support for:
  - SMART mode (uses current selection)
  - Explicit positioning (start, end, or offset)
  - Selection deletion before insertion (non-collapsed selections)
  - Text splitting with style preservation
  - Linebreak insertion in both Text and Linebreak blocks

- Refactor two existing Shift+Enter handlers to use prepareSoftbreak:
  - Text block "split" action handler (from ~30 lines to ~8 lines)
  - Direct Shift+Enter key handler (from ~50 lines to ~8 lines)

Benefits:
- Centralized softbreak logic in a single, reusable method
- Reduced code duplication (~70 lines removed)
- More maintainable and testable codebase
- Consistent behavior across different entry points